### PR TITLE
Re-add the missing Gene.get and Omim.get functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 - Refactored Gene and Disease annotations
 - Added proper hashing methods to ``HPOTerm``, ``Disease`` and ``Gene``
 - Bugfix for similarity score when one set does not contain any HPOTerm
+- 2.6.1: Re-add (Gene/Omim).get method for single gene/disease fetching. Needed in pyhpoapi
 
 2.5
 ---

--- a/pyhpo/__init__.py
+++ b/pyhpo/__init__.py
@@ -4,4 +4,4 @@
 
 # The following info will be used by setup.py and sphinx documentation
 __author__ = 'Jonas Marcello'
-__version__ = '2.6.0'
+__version__ = '2.6.1'

--- a/pyhpo/annotations.py
+++ b/pyhpo/annotations.py
@@ -209,6 +209,34 @@ class GeneDict(dict):
         self._names.clear()
         dict.clear(self)
 
+    def get(self, query):
+        """
+        Allows client to query for a gene by both ID and symbol.
+        This method is useful for client that do not want to add new
+        genes
+
+        Parameters
+        ----------
+        query: int or str
+            The (most likely user supplied) query.
+            Can be either the HGNC-ID or the gene symbol
+
+        Returns
+        -------
+        GeneSingleton
+            If a gene is found, it is returned. Otherwise an Error is raised
+        """
+        try:
+            idx = int(query)
+            return self._indicies[idx]
+        except (ValueError, KeyError):
+            idx = None
+
+        try:
+            return self._names[query]
+        except KeyError:
+            raise KeyError('No gene found for query')
+
 
 class DiseaseSingleton:
     """
@@ -411,6 +439,30 @@ class DiseaseDict(dict):
     def clear(self):
         self._indicies.clear()
         dict.clear(self)
+
+    def get(self, query):
+        """
+        Allows client to query for a disease by ID.
+        This method is useful for client that do not want to add new
+        diseases
+
+        Parameters
+        ----------
+        query: int
+            The (most likely user supplied) query for Disease ID.
+
+        Returns
+        -------
+        DiseaseSingleton
+            If a disease is found, it is returned. Otherwise an Error is raised
+        """
+        try:
+            idx = int(query)
+            return self._indicies[idx]
+        except ValueError:
+            raise ValueError('Invalid Disease ID supplied')
+        except KeyError:
+            raise KeyError('No disease found for query')
 
 
 class OmimDict(DiseaseDict):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -82,6 +82,24 @@ class OmimTests(unittest.TestCase):
     def test_hpo_association(self):
         pass
 
+    def test_get_omim(self):
+        Omim.clear()
+        d1 = Omim([None, 1, 'Gaucher'])
+        d2 = Omim([None, 2, 'Fabry'])
+
+        self.assertEqual(Omim.get(1), d1)
+        self.assertEqual(Omim.get(2), d2)
+        self.assertEqual(Omim.get('1'), d1)
+
+        self.assertRaises(
+            ValueError,
+            lambda: Omim.get('Fabry')
+        )
+        self.assertRaises(
+            KeyError,
+            lambda: Omim.get(12)
+        )
+
 
 class GeneTests(unittest.TestCase):
     def test_gene_building(self):
@@ -212,6 +230,26 @@ class GeneTests(unittest.TestCase):
 
     def test_hpo_association(self):
         pass
+
+    def test_get_gene(self):
+        Gene.clear()
+        g1 = Gene([None, None, 1, 'EZH1'])
+        g2 = Gene([None, None, 2, 'EZH2'])
+
+        self.assertEqual(Gene.get(1), g1)
+        self.assertEqual(Gene.get(2), g2)
+        self.assertEqual(Gene.get('1'), g1)
+        self.assertEqual(Gene.get('EZH1'), g1)
+        self.assertEqual(Gene.get('EZH2'), g2)
+
+        self.assertRaises(
+            KeyError,
+            lambda: Gene.get('GBA')
+        )
+        self.assertRaises(
+            KeyError,
+            lambda: Gene.get(12)
+        )
 
 
 @unittest.skip('TODO')


### PR DESCRIPTION
These functions were removed during Gene and Disease refactoring, but they are needed for pyhpoapi