### PR TITLE
Fix a bug with f-strings in Python3.6 and 3.7.

### DIFF
--- a/.github/workflows/python_versions.yaml
+++ b/.github/workflows/python_versions.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 2.7
 ---
 - Added type annotation to all methods
+- ``Ontology.get_hpo_object`` now behaves as documented and raises an error if the term is not found instead of silently returning None
 
 2.6
 ---

--- a/pyhpo/__init__.py
+++ b/pyhpo/__init__.py
@@ -11,7 +11,7 @@ from pyhpo.annotations import OmimDisease, OrphaDisease, DecipherDisease
 
 # The following info will be used by setup.py and sphinx documentation
 __author__ = 'Jonas Marcello'
-__version__ = '2.7'
+__version__ = '2.7.1'
 
 __all__ = (
     'Annotation',

--- a/pyhpo/term.py
+++ b/pyhpo/term.py
@@ -46,7 +46,7 @@ class HPOAnnotation:
             raise KeyError(f'Invalid key for HPO Term annotation {key}')
 
     def __str__(self) -> str:
-        return f'{self.items=} | {self.cached=}'
+        return f'items={self.items} | cached={self.cached}'
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -137,7 +137,7 @@ class TermInit(unittest.TestCase):
             self.assertEqual(
                 a.__getattribute__(attrs),
                 b.__getattribute__(attrs),
-                f'Difference in {attrs=}'
+                f'Difference in {attrs}'
             )
 
 


### PR DESCRIPTION
The debugging specifier {example=} was only introduced in Python3.8 so we removed it to allow
compatibility with 3.6 and 3.7